### PR TITLE
Pass --delete option to aws s3 sync

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,8 +42,8 @@ steps:
   - name: sync (test)
     image: 72636c/aws-cli:1
     commands:
-      - aws s3 sync naked-bucket s3://test.bryceandryanforeverandever.net
-      - aws s3 sync www-bucket s3://www.test.bryceandryanforeverandever.net
+      - aws s3 sync --delete naked-bucket s3://test.bryceandryanforeverandever.net
+      - aws s3 sync --delete www-bucket s3://www.test.bryceandryanforeverandever.net
     environment:
       <<: *environment
       ENVIRONMENT: test
@@ -80,8 +80,8 @@ steps:
   - name: sync (prod)
     image: 72636c/aws-cli:1
     commands:
-      - aws s3 sync naked-bucket s3://bryceandryanforeverandever.net
-      - aws s3 sync www-bucket s3://www.bryceandryanforeverandever.net
+      - aws s3 sync --delete naked-bucket s3://bryceandryanforeverandever.net
+      - aws s3 sync --delete www-bucket s3://www.bryceandryanforeverandever.net
     environment:
       <<: *environment
       ENVIRONMENT: prod
@@ -93,4 +93,4 @@ steps:
 
 ---
 kind: signature
-hmac: 335724cbf57b9c042e61c19a453b7f47ccb19b212ca6e4be45d74c77c5d7cb09
+hmac: aa3040696583d8f02736f1600a79bb57250a5bcc300bb9f9b430319a1fdf7e6a

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ scripts/request-certificates.sh
 ```shell
 AWS_REGION=us-east-1 ENVIRONMENT=test stratus deploy
 
-aws s3 sync naked-bucket s3://test.bryceandryanforeverandever.net
-aws s3 sync www-bucket s3://www.test.bryceandryanforeverandever.net
+aws s3 sync --delete naked-bucket s3://test.bryceandryanforeverandever.net
+aws s3 sync --delete www-bucket s3://www.test.bryceandryanforeverandever.net
 ```
 
 ### Prod
@@ -26,6 +26,6 @@ aws s3 sync www-bucket s3://www.test.bryceandryanforeverandever.net
 ```shell
 AWS_REGION=us-east-1 ENVIRONMENT=prod stratus deploy
 
-aws s3 sync naked-bucket s3://bryceandryanforeverandever.net
-aws s3 sync www-bucket s3://www.bryceandryanforeverandever.net
+aws s3 sync --delete naked-bucket s3://bryceandryanforeverandever.net
+aws s3 sync --delete www-bucket s3://www.bryceandryanforeverandever.net
 ```


### PR DESCRIPTION
Delete any S3 objects that are not used by the latest release, which is
reasonable until proper versioning is implemented.